### PR TITLE
validación del protocolo

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,16 @@ const rutas = [
   "Juegos/ahorcado/metadata.json"
 ];
 
+// 🚨 Validación de protocolo
+function verificarProtocolo() {
+  if (location.protocol === 'file:') {
+    alert("⚠️ Este proyecto debe ejecutarse desde un servidor local.\n\nUsá Live Server, Python o Node para que los juegos se carguen correctamente.");
+  }
+}
+
+verificarProtocolo();
+
+
 const contenedor = document.getElementById("juegos-container");
 const inputBusqueda = document.getElementById("busqueda");
 const selectTags = document.getElementById("filtro-tags");


### PR DESCRIPTION
Agrego una  la instrucción al inicio del main.js para evitar que el proyecto se ejecute directamente, lo que bloquea las peticiones fetch.

Se muestra un alert preventivo si el protocolo no es `http` o `https`, guiando al usuario a usar Live Server, Python o Node.

